### PR TITLE
[WIP] Migrations necessary for Edgeware Node Upgrade

### DIFF
--- a/frame/balances/Cargo.toml
+++ b/frame/balances/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1.0.101", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 sp-std = { version = "2.0.0-rc2", default-features = false, path = "../../primitives/std" }
 sp-runtime = { version = "2.0.0-rc2", default-features = false, path = "../../primitives/runtime" }
+sp-io = { version = "2.0.0-rc2", default-features = false, path = "../../primitives/io" }
 frame-benchmarking = { version = "2.0.0-rc2", default-features = false, path = "../benchmarking", optional = true }
 frame-support = { version = "2.0.0-rc2", default-features = false, path = "../support" }
 frame-system = { version = "2.0.0-rc2", default-features = false, path = "../system" }

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -154,6 +154,7 @@ mod tests;
 mod tests_local;
 mod tests_composite;
 mod benchmarking;
+mod migration;
 
 use sp_std::prelude::*;
 use sp_std::{cmp, result, mem, fmt::Debug, ops::BitOr, convert::Infallible};
@@ -542,6 +543,28 @@ decl_module! {
 			let dest = T::Lookup::lookup(dest)?;
 			<Self as Currency<_>>::transfer(&transactor, &dest, value, KeepAlive)?;
 		}
+
+		fn on_runtime_upgrade() {
+			migration::on_runtime_upgrade::<T, I>();
+		}
+	}
+}
+
+#[derive(Decode)]
+struct OldBalanceLock<Balance, BlockNumber> {
+	id: LockIdentifier,
+	amount: Balance,
+	until: BlockNumber,
+	reasons: WithdrawReasons,
+}
+
+impl<Balance, BlockNumber> OldBalanceLock<Balance, BlockNumber> {
+	fn upgraded(self) -> (BalanceLock<Balance>, BlockNumber) {
+		(BalanceLock {
+			id: self.id,
+			amount: self.amount,
+			reasons: self.reasons.into(),
+		}, self.until)
 	}
 }
 

--- a/frame/balances/src/lib.rs
+++ b/frame/balances/src/lib.rs
@@ -166,7 +166,8 @@ use frame_support::{
 		WithdrawReason, WithdrawReasons, LockIdentifier, LockableCurrency, ExistenceRequirement,
 		Imbalance, SignedImbalance, ReservableCurrency, Get, ExistenceRequirement::KeepAlive,
 		ExistenceRequirement::AllowDeath, IsDeadAccount, BalanceStatus as Status,
-	}
+	},
+	weights::Weight,
 };
 use sp_runtime::{
 	RuntimeDebug, DispatchResult, DispatchError,
@@ -544,8 +545,9 @@ decl_module! {
 			<Self as Currency<_>>::transfer(&transactor, &dest, value, KeepAlive)?;
 		}
 
-		fn on_runtime_upgrade() {
+		fn on_runtime_upgrade() -> Weight {
 			migration::on_runtime_upgrade::<T, I>();
+			1000
 		}
 	}
 }

--- a/frame/balances/src/migration.rs
+++ b/frame/balances/src/migration.rs
@@ -1,0 +1,112 @@
+// Copyright 2020 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Temporary migrations of the balances module.
+
+use super::*;
+
+pub fn on_runtime_upgrade<T: Trait<I>, I: Instance>() {
+	match StorageVersion::<I>::get() {
+		Releases::V2_0_0 => return,
+		Releases::V1_0_0 => upgrade_v1_to_v2::<T, I>(),
+	}
+}
+
+// Upgrade from the pre-#4649 balances/vesting into the new balances.
+fn upgrade_v1_to_v2<T: Trait<I>, I: Instance>() {
+	sp_runtime::print("Upgrading account balances...");
+	// First, migrate from old FreeBalance to new Account.
+	// We also move all locks across since only accounts with FreeBalance values have locks.
+	// FreeBalance: map T::AccountId => T::Balance
+	for (hash, free) in StorageIterator::<T::Balance>::new(b"Balances", b"FreeBalance").drain() {
+		let mut account = AccountData { free, ..Default::default() };
+		// Locks: map T::AccountId => Vec<BalanceLock>
+		let old_locks = get_storage_value::<Vec<OldBalanceLock<T::Balance, T::BlockNumber>>>(b"Balances", b"Locks", &hash);
+		if let Some(locks) = old_locks {
+			let locks = locks.into_iter()
+				.map(|i| {
+					let (result, expiry) = i.upgraded();
+					if expiry != T::BlockNumber::max_value() {
+						// Any `until`s that are not T::BlockNumber::max_value come from
+						// democracy and need to be migrated over there.
+						// Democracy: Locks get(locks): map T::AccountId => Option<T::BlockNumber>;
+						put_storage_value(b"Democracy", b"Locks", &hash, expiry);
+					}
+					result
+				})
+				.collect::<Vec<_>>();
+			for l in locks.iter() {
+				if l.reasons == Reasons::All || l.reasons == Reasons::Misc {
+					account.misc_frozen = account.misc_frozen.max(l.amount);
+				}
+				if l.reasons == Reasons::All || l.reasons == Reasons::Fee {
+					account.fee_frozen = account.fee_frozen.max(l.amount);
+				}
+			}
+			put_storage_value(b"Balances", b"Locks", &hash, locks);
+		}
+		put_storage_value(b"Balances", b"Account", &hash, account);
+	}
+	// Second, migrate old ReservedBalance into new Account.
+	// ReservedBalance: map T::AccountId => T::Balance
+	for (hash, reserved) in StorageIterator::<T::Balance>::new(b"Balances", b"ReservedBalance").drain() {
+		let mut account = get_storage_value::<AccountData<T::Balance>>(b"Balances", b"Account", &hash).unwrap_or_default();
+		account.reserved = reserved;
+		put_storage_value(b"Balances", b"Account", &hash, account);
+	}
+
+	// Finally, migrate vesting and ensure locks are in place. We will be lazy and just lock
+	// for the maximum amount (i.e. at genesis). Users will need to call "vest" to reduce the
+	// lock to something sensible.
+	// pub Vesting: map T::AccountId => Option<VestingSchedule>;
+	for (hash, vesting) in StorageIterator::<(T::Balance, T::Balance, T::BlockNumber)>::new(b"Balances", b"Vesting").drain() {
+		let mut account = get_storage_value::<AccountData<T::Balance>>(b"Balances", b"Account", &hash).unwrap_or_default();
+		let mut locks = get_storage_value::<Vec<BalanceLock<T::Balance>>>(b"Balances", b"Locks", &hash).unwrap_or_default();
+		locks.push(BalanceLock {
+			id: *b"vesting ",
+			amount: vesting.0.clone(),
+			reasons: Reasons::Misc,
+		});
+		account.misc_frozen = account.misc_frozen.max(vesting.0.clone());
+		put_storage_value(b"Vesting", b"Vesting", &hash, vesting);
+		put_storage_value(b"Balances", b"Locks", &hash, locks);
+		put_storage_value(b"Balances", b"Account", &hash, account);
+	}
+
+	let prefix = {
+		let encoded_prefix_key_hash = b":session:keys".to_vec().encode();
+		let mut h = twox_64(&encoded_prefix_key_hash[..]).to_vec();
+		h.extend(&encoded_prefix_key_hash[..]);
+		h
+	};
+
+	for (hash, balances) in StorageIterator::<AccountData<T::Balance>>::new(b"Balances", b"Account").drain() {
+		let nonce = take_storage_value::<T::Index>(b"System", b"AccountNonce", &hash).unwrap_or_default();
+		let mut refs: system::RefCount = 0;
+		// The items in Kusama that would result in a ref count being incremented.
+		if have_storage_value(b"Democracy", b"Proxy", &hash) { refs += 1 }
+		// We skip Recovered since it's being replaced anyway.
+		let mut prefixed_hash = prefix.clone();
+		prefixed_hash.extend(&hash[..]);
+		if have_storage_value(b"Session", b"NextKeys", &prefixed_hash) { refs += 1 }
+		if have_storage_value(b"Staking", b"Bonded", &hash) { refs += 1 }
+		put_storage_value(b"System", b"Account", &hash, (nonce, refs, &balances));
+	}
+
+	take_storage_value::<T::Index>(b"Balances", b"IsUpgraded", &[]);
+
+	StorageVersion::<I>::put(Releases::V2_0_0);
+}

--- a/frame/balances/src/migration.rs
+++ b/frame/balances/src/migration.rs
@@ -18,6 +18,11 @@
 
 use super::*;
 
+use frame_support::storage::migration::{
+	get_storage_value, have_storage_value, put_storage_value, take_storage_value, StorageIterator
+};
+use sp_io::hashing::twox_64;
+
 pub fn on_runtime_upgrade<T: Trait<I>, I: Instance>() {
 	match StorageVersion::<I>::get() {
 		Releases::V2_0_0 => return,

--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -16,12 +16,12 @@
 // limitations under the License.
 
 //! # Democracy Pallet
-//!
+//! 
 //! - [`democracy::Trait`](./trait.Trait.html)
 //! - [`Call`](./enum.Call.html)
 //!
 //! ## Overview
-//!
+//! 
 //! The Democracy pallet handles the administration of general stakeholder voting.
 //!
 //! There are two different queues that a proposal can be added to before it
@@ -29,7 +29,7 @@
 //! and 2) the external queue consisting of a single proposal that originates
 //! from one of the _external_ origins (such as a collective group).
 //!
-//! Every launch period - a length defined in the runtime - the Democracy pallet
+//! Every launch period - a length defined in the runtime - the Democracy pallet 
 //! launches a referendum from a proposal that it takes from either the proposal
 //! queue or the external queue in turn. Any token holder in the system can vote
 //! on referenda. The voting system
@@ -40,7 +40,7 @@
 //! ### Terminology
 //!
 //! - **Enactment Period:** The minimum period of locking and the period between a proposal being
-//! approved and enacted.
+//! approved and enacted. 
 //! - **Lock Period:** A period of time after proposal enactment that the tokens of _winning_ voters
 //! will be locked.
 //! - **Conviction:** An indication of a voter's strength of belief in their vote. An increase
@@ -50,7 +50,7 @@
 //!   of a particular referendum.
 //! - **Proposal:** A submission to the chain that represents an action that a proposer (either an
 //! account or an external origin) suggests that the system adopt.
-//! - **Referendum:** A proposal that is in the process of being voted on for
+//! - **Referendum:** A proposal that is in the process of being voted on for 
 //!   either acceptance or rejection as a change to the system.
 //! - **Proxy:** An account that has full voting power on behalf of a separate "Stash" account
 //!   that holds the funds.
@@ -62,7 +62,7 @@
 //! A _referendum_ can be either simple majority-carries in which 50%+1 of the
 //! votes decide the outcome or _adaptive quorum biased_. Adaptive quorum biasing
 //! makes the threshold for passing or rejecting a referendum higher or lower
-//! depending on how the referendum was originally proposed. There are two types of
+//! depending on how the referendum was originally proposed. There are two types of 
 //! adaptive quorum biasing: 1) _positive turnout bias_ makes a referendum
 //! require a super-majority to pass that decreases as turnout increases and
 //! 2) _negative turnout bias_ makes a referendum require a super-majority to
@@ -113,7 +113,7 @@
 //!   Does not require a deposit, but the proposal must be in the dispatch queue.
 //! - `note_imminent_preimage_operational` - same but provided by `T::OperationalPreimageOrigin`.
 //! - `reap_preimage` - Removes the preimage for an expired proposal. Will only
-//!   work under the condition that it's the same account that noted it and
+//!   work under the condition that it's the same account that noted it and 
 //!   after the voting period, OR it's a different account after the enactment period.
 //!
 //! #### Cancellation Origin
@@ -152,7 +152,7 @@
 //!   is "majority-carries" to become a referendum immediately.
 //!
 //! #### Veto Origin
-//!
+//! 
 //! This call can only be made by the `VetoOrigin`.
 //!
 //! - `veto_external` - Vetoes and blacklists the external proposal hash.
@@ -851,7 +851,7 @@ decl_module! {
 		/// an external referendum.
 		///
 		/// The dispatch of this call must be `ExternalMajorityOrigin`.
-		///
+		/// 
 		/// - `proposal_hash`: The preimage hash of the proposal.
 		///
 		/// Unlike `external_propose`, blacklisting has no effect on this and it may replace a
@@ -948,7 +948,7 @@ decl_module! {
 		/// Veto and blacklist the external proposal hash.
 		///
 		/// The dispatch origin of this call must be `VetoOrigin`.
-		///
+		/// 
 		/// - `proposal_hash`: The preimage hash of the proposal to veto and blacklist.
 		///
 		/// Emits `Vetoed`.

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -230,7 +230,7 @@ decl_module! {
 			Self::update_lock(T::Lookup::lookup(target)?)
 		}
 
-		/// Create a vested transfer.
+		/// Create a vested transfer. 
 		///
 		/// The dispatch origin for this call must be _Signed_.
 		///
@@ -259,12 +259,12 @@ decl_module! {
 
 			let who = T::Lookup::lookup(target)?;
 			ensure!(!Vesting::<T>::contains_key(&who), Error::<T>::ExistingVestingSchedule);
-
+			
 			T::Currency::transfer(&transactor, &who, schedule.locked, ExistenceRequirement::AllowDeath)?;
 
 			Self::add_vesting_schedule(&who, schedule.locked, schedule.per_block, schedule.starting_block)
 				.expect("user does not have an existing vesting schedule; q.e.d.");
-
+			
 			Ok(())
 		}
 	}
@@ -471,6 +471,54 @@ mod tests {
 			ext.execute_with(|| System::set_block_number(1));
 			ext
 		}
+	}
+
+	#[test]
+	fn vesting_info_via_migration_should_work() {
+		let mut s = Storage::default();
+		use hex_literal::hex;
+		// A dump of data from the previous version for which we know account 6 vests 30 of its 60
+		// over 5  blocks from block 3.
+		let data = vec![
+			(hex!["26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac"].to_vec(), hex!["0100000000000000"].to_vec()),
+			(hex!["26aa394eea5630e07c48ae0c9558cef70a98fdbe9ce6c55837576c60c7af3850"].to_vec(), hex!["02000000"].to_vec()),
+			(hex!["26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7"].to_vec(), hex!["08000000000000000000000000"].to_vec()),
+			(hex!["26aa394eea5630e07c48ae0c9558cef78a42f33323cb5ced3b44dd825fda9fcc"].to_vec(), hex!["4545454545454545454545454545454545454545454545454545454545454545"].to_vec()),
+			(hex!["26aa394eea5630e07c48ae0c9558cef7a44704b568d21667356a5a050c11874681e47a19e6b29b0a65b9591762ce5143ed30d0261e5d24a3201752506b20f15c"].to_vec(), hex!["4545454545454545454545454545454545454545454545454545454545454545"].to_vec()),
+			(hex!["3a636f6465"].to_vec(), hex![""].to_vec()),
+			(hex!["3a65787472696e7369635f696e646578"].to_vec(), hex!["00000000"].to_vec()),
+			(hex!["3a686561707061676573"].to_vec(), hex!["0800000000000000"].to_vec()),
+			(hex!["c2261276cc9d1f8598ea4b6a74b15c2f218f26c73add634897550b4003b26bc61dbd7d0b561a41d23c2a469ad42fbd70d5438bae826f6fd607413190c37c363b"].to_vec(), hex!["046d697363202020200300000000000000ffffffffffffffff04"].to_vec()),
+			(hex!["c2261276cc9d1f8598ea4b6a74b15c2f218f26c73add634897550b4003b26bc66cddb367afbd583bb48f9bbd7d5ba3b1d0738b4881b1cddd38169526d8158137"].to_vec(), hex!["0474786665657320200300000000000000ffffffffffffffff01"].to_vec()),
+			(hex!["c2261276cc9d1f8598ea4b6a74b15c2f218f26c73add634897550b4003b26bc6e88b43fded6323ef02ffeffbd8c40846ee09bf316271bd22369659c959dd733a"].to_vec(), hex!["08616c6c20202020200300000000000000ffffffffffffffff1f64656d6f63726163ffffffffffffffff030000000000000002"].to_vec()),
+			(hex!["c2261276cc9d1f8598ea4b6a74b15c2f3c22813def93ef32c365b55cb92f10f91dbd7d0b561a41d23c2a469ad42fbd70d5438bae826f6fd607413190c37c363b"].to_vec(), hex!["0500000000000000"].to_vec()),
+			(hex!["c2261276cc9d1f8598ea4b6a74b15c2f57c875e4cff74148e4628f264b974c80"].to_vec(), hex!["d200000000000000"].to_vec()),
+			(hex!["c2261276cc9d1f8598ea4b6a74b15c2f5f27b51b5ec208ee9cb25b55d8728243b8788bb218b185b63e3e92653953f29b6b143fb8cf5159fc908632e6fe490501"].to_vec(), hex!["1e0000000000000006000000000000000200000000000000"].to_vec()),
+			(hex!["c2261276cc9d1f8598ea4b6a74b15c2f6482b9ade7bc6657aaca787ba1add3b41dbd7d0b561a41d23c2a469ad42fbd70d5438bae826f6fd607413190c37c363b"].to_vec(), hex!["0500000000000000"].to_vec()),
+			(hex!["c2261276cc9d1f8598ea4b6a74b15c2f6482b9ade7bc6657aaca787ba1add3b46cddb367afbd583bb48f9bbd7d5ba3b1d0738b4881b1cddd38169526d8158137"].to_vec(), hex!["1e00000000000000"].to_vec()),
+			(hex!["c2261276cc9d1f8598ea4b6a74b15c2f6482b9ade7bc6657aaca787ba1add3b4b8788bb218b185b63e3e92653953f29b6b143fb8cf5159fc908632e6fe490501"].to_vec(), hex!["3c00000000000000"].to_vec()),
+			(hex!["c2261276cc9d1f8598ea4b6a74b15c2f6482b9ade7bc6657aaca787ba1add3b4e88b43fded6323ef02ffeffbd8c40846ee09bf316271bd22369659c959dd733a"].to_vec(), hex!["1400000000000000"].to_vec()),
+			(hex!["c2261276cc9d1f8598ea4b6a74b15c2f6482b9ade7bc6657aaca787ba1add3b4e96760d274653a39b429a87ebaae9d3aa4fdf58b9096cf0bebc7c4e5a4c2ed8d"].to_vec(), hex!["2800000000000000"].to_vec()),
+			(hex!["c2261276cc9d1f8598ea4b6a74b15c2f6482b9ade7bc6657aaca787ba1add3b4effb728943197fd12e694cbf3f3ede28fbf7498b0370c6dfa0013874b417c178"].to_vec(), hex!["3200000000000000"].to_vec()),
+			(hex!["f2794c22e353e9a839f12faab03a911b7f17cdfbfa73331856cca0acddd7842e"].to_vec(), hex!["00000000"].to_vec()),
+			(hex!["f2794c22e353e9a839f12faab03a911bbdcb0c5143a8617ed38ae3810dd45bc6"].to_vec(), hex!["00000000"].to_vec()),
+			(hex!["f2794c22e353e9a839f12faab03a911be2f6cb0456905c189bcb0458f9440f13"].to_vec(), hex!["00000000"].to_vec()),
+		];
+		s.top = data.into_iter().collect();
+		sp_io::TestExternalities::new(s).execute_with(|| {
+			Balances::on_runtime_upgrade();
+			assert_eq!(Balances::free_balance(6), 60);
+			assert_eq!(Balances::usable_balance(&6), 30);
+			System::set_block_number(2);
+			assert_ok!(Vesting::vest(Origin::signed(6)));
+			assert_eq!(Balances::usable_balance(&6), 30);
+			System::set_block_number(3);
+			assert_ok!(Vesting::vest(Origin::signed(6)));
+			assert_eq!(Balances::usable_balance(&6), 36);
+			System::set_block_number(4);
+			assert_ok!(Vesting::vest(Origin::signed(6)));
+			assert_eq!(Balances::usable_balance(&6), 42);
+		});
 	}
 
 	#[test]

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -474,54 +474,6 @@ mod tests {
 	}
 
 	#[test]
-	fn vesting_info_via_migration_should_work() {
-		let mut s = Storage::default();
-		use hex_literal::hex;
-		// A dump of data from the previous version for which we know account 6 vests 30 of its 60
-		// over 5  blocks from block 3.
-		let data = vec![
-			(hex!["26aa394eea5630e07c48ae0c9558cef702a5c1b19ab7a04f536c519aca4983ac"].to_vec(), hex!["0100000000000000"].to_vec()),
-			(hex!["26aa394eea5630e07c48ae0c9558cef70a98fdbe9ce6c55837576c60c7af3850"].to_vec(), hex!["02000000"].to_vec()),
-			(hex!["26aa394eea5630e07c48ae0c9558cef780d41e5e16056765bc8461851072c9d7"].to_vec(), hex!["08000000000000000000000000"].to_vec()),
-			(hex!["26aa394eea5630e07c48ae0c9558cef78a42f33323cb5ced3b44dd825fda9fcc"].to_vec(), hex!["4545454545454545454545454545454545454545454545454545454545454545"].to_vec()),
-			(hex!["26aa394eea5630e07c48ae0c9558cef7a44704b568d21667356a5a050c11874681e47a19e6b29b0a65b9591762ce5143ed30d0261e5d24a3201752506b20f15c"].to_vec(), hex!["4545454545454545454545454545454545454545454545454545454545454545"].to_vec()),
-			(hex!["3a636f6465"].to_vec(), hex![""].to_vec()),
-			(hex!["3a65787472696e7369635f696e646578"].to_vec(), hex!["00000000"].to_vec()),
-			(hex!["3a686561707061676573"].to_vec(), hex!["0800000000000000"].to_vec()),
-			(hex!["c2261276cc9d1f8598ea4b6a74b15c2f218f26c73add634897550b4003b26bc61dbd7d0b561a41d23c2a469ad42fbd70d5438bae826f6fd607413190c37c363b"].to_vec(), hex!["046d697363202020200300000000000000ffffffffffffffff04"].to_vec()),
-			(hex!["c2261276cc9d1f8598ea4b6a74b15c2f218f26c73add634897550b4003b26bc66cddb367afbd583bb48f9bbd7d5ba3b1d0738b4881b1cddd38169526d8158137"].to_vec(), hex!["0474786665657320200300000000000000ffffffffffffffff01"].to_vec()),
-			(hex!["c2261276cc9d1f8598ea4b6a74b15c2f218f26c73add634897550b4003b26bc6e88b43fded6323ef02ffeffbd8c40846ee09bf316271bd22369659c959dd733a"].to_vec(), hex!["08616c6c20202020200300000000000000ffffffffffffffff1f64656d6f63726163ffffffffffffffff030000000000000002"].to_vec()),
-			(hex!["c2261276cc9d1f8598ea4b6a74b15c2f3c22813def93ef32c365b55cb92f10f91dbd7d0b561a41d23c2a469ad42fbd70d5438bae826f6fd607413190c37c363b"].to_vec(), hex!["0500000000000000"].to_vec()),
-			(hex!["c2261276cc9d1f8598ea4b6a74b15c2f57c875e4cff74148e4628f264b974c80"].to_vec(), hex!["d200000000000000"].to_vec()),
-			(hex!["c2261276cc9d1f8598ea4b6a74b15c2f5f27b51b5ec208ee9cb25b55d8728243b8788bb218b185b63e3e92653953f29b6b143fb8cf5159fc908632e6fe490501"].to_vec(), hex!["1e0000000000000006000000000000000200000000000000"].to_vec()),
-			(hex!["c2261276cc9d1f8598ea4b6a74b15c2f6482b9ade7bc6657aaca787ba1add3b41dbd7d0b561a41d23c2a469ad42fbd70d5438bae826f6fd607413190c37c363b"].to_vec(), hex!["0500000000000000"].to_vec()),
-			(hex!["c2261276cc9d1f8598ea4b6a74b15c2f6482b9ade7bc6657aaca787ba1add3b46cddb367afbd583bb48f9bbd7d5ba3b1d0738b4881b1cddd38169526d8158137"].to_vec(), hex!["1e00000000000000"].to_vec()),
-			(hex!["c2261276cc9d1f8598ea4b6a74b15c2f6482b9ade7bc6657aaca787ba1add3b4b8788bb218b185b63e3e92653953f29b6b143fb8cf5159fc908632e6fe490501"].to_vec(), hex!["3c00000000000000"].to_vec()),
-			(hex!["c2261276cc9d1f8598ea4b6a74b15c2f6482b9ade7bc6657aaca787ba1add3b4e88b43fded6323ef02ffeffbd8c40846ee09bf316271bd22369659c959dd733a"].to_vec(), hex!["1400000000000000"].to_vec()),
-			(hex!["c2261276cc9d1f8598ea4b6a74b15c2f6482b9ade7bc6657aaca787ba1add3b4e96760d274653a39b429a87ebaae9d3aa4fdf58b9096cf0bebc7c4e5a4c2ed8d"].to_vec(), hex!["2800000000000000"].to_vec()),
-			(hex!["c2261276cc9d1f8598ea4b6a74b15c2f6482b9ade7bc6657aaca787ba1add3b4effb728943197fd12e694cbf3f3ede28fbf7498b0370c6dfa0013874b417c178"].to_vec(), hex!["3200000000000000"].to_vec()),
-			(hex!["f2794c22e353e9a839f12faab03a911b7f17cdfbfa73331856cca0acddd7842e"].to_vec(), hex!["00000000"].to_vec()),
-			(hex!["f2794c22e353e9a839f12faab03a911bbdcb0c5143a8617ed38ae3810dd45bc6"].to_vec(), hex!["00000000"].to_vec()),
-			(hex!["f2794c22e353e9a839f12faab03a911be2f6cb0456905c189bcb0458f9440f13"].to_vec(), hex!["00000000"].to_vec()),
-		];
-		s.top = data.into_iter().collect();
-		sp_io::TestExternalities::new(s).execute_with(|| {
-			Balances::on_runtime_upgrade();
-			assert_eq!(Balances::free_balance(6), 60);
-			assert_eq!(Balances::usable_balance(&6), 30);
-			System::set_block_number(2);
-			assert_ok!(Vesting::vest(Origin::signed(6)));
-			assert_eq!(Balances::usable_balance(&6), 30);
-			System::set_block_number(3);
-			assert_ok!(Vesting::vest(Origin::signed(6)));
-			assert_eq!(Balances::usable_balance(&6), 36);
-			System::set_block_number(4);
-			assert_ok!(Vesting::vest(Origin::signed(6)));
-			assert_eq!(Balances::usable_balance(&6), 42);
-		});
-	}
-
-	#[test]
 	fn check_vesting_status() {
 		ExtBuilder::default()
 			.existential_deposit(256)


### PR DESCRIPTION
PR for creating the migrations necessary for the runtime upgrade from `v1.0.1redo` to `time-travel`.

### Included Migrations
+ balances migration (Revert "Remove balances migration. (#5224)" (This reverts commit `e1fcc9796a576a9fb78e0a5e23830ae87171015b`)).

related to https://github.com/hicommonwealth/edgeware-node/issues/164